### PR TITLE
Permito configurar EntityManagerFactory antes de la inicialización

### DIFF
--- a/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerAccess.java
+++ b/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerAccess.java
@@ -1,6 +1,10 @@
 package com.github.flbulgarelli.jpa.extras.perthread;
 
-
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -8,34 +12,98 @@ import javax.persistence.Persistence;
 /**
  * @author gprieto
  * @author flbulgarelli
+ * @author raniagus
  */
 public class PerThreadEntityManagerAccess {
 
-  private EntityManagerFactory emf;
+  private volatile EntityManagerFactory emf;
 
-  private ThreadLocal<EntityManager> threadLocal;
+  private final String persistenceUnitName;
+
+  private final ThreadLocal<EntityManager> threadLocal;
+
+  private final Properties properties;
 
   public PerThreadEntityManagerAccess(String persistenceUnitName) {
-    emf = Persistence.createEntityManagerFactory(persistenceUnitName);
-    threadLocal = new ThreadLocal<>();
+    this.persistenceUnitName = persistenceUnitName;
+    this.threadLocal = new ThreadLocal<>();
+    this.properties = new Properties();
+  }
+
+  private void ensureNotInitialized() {
+    synchronized (this) {
+      if (emf != null) {
+        throw new IllegalStateException("Can not set properties after initialization");
+      }
+    }
+  }
+
+  /**
+   * Sets a property before the entity manager factory is created.
+   *
+   * @param key the property key
+   * @param value the property value
+   * @throws IllegalStateException if the entity manager factory has already been created
+   */
+  public PerThreadEntityManagerAccess setProperty(String key, String value) {
+    ensureNotInitialized();
+    this.properties.setProperty(key, value);
+    return this;
+  }
+
+  /**
+   * Sets a map of properties to be used when creating the entity manager factory.
+   *
+   * @param properties the properties to set
+   * @throws IllegalStateException if the entity manager factory has already been created
+   */
+  public <K, V> PerThreadEntityManagerAccess setProperties(Map<K, V> properties) {
+    ensureNotInitialized();
+    this.properties.putAll(properties);
+    return this;
+  }
+
+  /**
+   * Loads properties from a file and sets them before the entity manager factory is created.
+   *
+   * @param path the path to the properties file
+   * @throws IllegalStateException if the entity manager factory has already been created
+   * @throws IOException if the file can not be read
+   */
+  public PerThreadEntityManagerAccess loadProperties(String path) throws IOException {
+    ensureNotInitialized();
+    this.properties.load(Files.newInputStream(Paths.get(path)));
+    return this;
+  }
+
+  private EntityManagerFactory getEmf() {
+    if (emf == null) {
+      synchronized (this) {
+        if (emf == null) {
+          emf = Persistence.createEntityManagerFactory(
+              persistenceUnitName, properties);
+        }
+      }
+    }
+    return emf;
   }
 
   /**
    * Shutdowns this access, preventing new entity managers to be produced
    */
   public void shutdown() {
-    emf.close();
+    getEmf().close();
   }
 
   /**
    * @return whether {@link #shutdown()} has been called yet
    */
   public boolean isActive() {
-    return emf.isOpen();
+    return getEmf().isOpen();
   }
 
   private void ensureActive() {
-    if (!emf.isOpen()) {
+    if (!getEmf().isOpen()) {
       throw new IllegalStateException("Can not get an entity manager before initialize or after shutdown");
     }
   }

--- a/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerAccess.java
+++ b/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerAccess.java
@@ -87,7 +87,7 @@ public class PerThreadEntityManagerAccess {
     ensureActive();
     EntityManager manager = threadLocal.get();
     if (manager == null || !manager.isOpen()) {
-      manager = emf.createEntityManager();
+      manager = getEmf().createEntityManager();
       threadLocal.set(manager);
     }
     return manager;

--- a/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerProperties.java
+++ b/src/main/java/com/github/flbulgarelli/jpa/extras/perthread/PerThreadEntityManagerProperties.java
@@ -1,0 +1,60 @@
+package com.github.flbulgarelli.jpa.extras.perthread;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author raniagus
+ */
+public class PerThreadEntityManagerProperties {
+  private final Properties properties = new Properties();
+
+  /**
+   * Sets a property before the entity manager factory is created.
+   *
+   * @param key the property key
+   * @param value the property value
+   * @throws NullPointerException if the key or value is null
+   */
+  public PerThreadEntityManagerProperties set(String key, String value) {
+    this.properties.setProperty(key, value);
+    return this;
+  }
+
+  /**
+   * Sets a map of properties to be used when creating the entity manager factory.
+   *
+   * @param properties the properties to set
+   * @throws NullPointerException if the properties map is null
+   */
+  public <K, V> PerThreadEntityManagerProperties putAll(Map<K, V> properties) {
+    this.properties.putAll(properties);
+    return this;
+  }
+
+  /**
+   * Loads properties from a file and sets them before the entity manager factory is created.
+   *
+   * @param path the path to the properties file
+   * @throws UncheckedIOException if the file can not be read
+   */
+  public PerThreadEntityManagerProperties load(String path) {
+    try {
+      this.properties.load(Files.newInputStream(Paths.get(path)));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return this;
+  }
+
+  /**
+   * Returns the properties for the entity manager.
+   */
+  public Properties get() {
+    return properties;
+  }
+}

--- a/src/main/java/com/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
+++ b/src/main/java/com/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
@@ -3,7 +3,9 @@ package com.github.flbulgarelli.jpa.extras.simple;
 import com.github.flbulgarelli.jpa.extras.EntityManagerOps;
 import com.github.flbulgarelli.jpa.extras.TransactionalOps;
 import com.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerAccess;
+import com.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerProperties;
 import com.github.flbulgarelli.jpa.extras.perthread.WithPerThreadEntityManager;
+import java.util.function.Consumer;
 
 /**
  * This mixin-style interface allows implementors
@@ -18,6 +20,16 @@ public interface WithSimplePersistenceUnit extends WithPerThreadEntityManager, E
   @Override
   default PerThreadEntityManagerAccess perThreadEntityManagerAccess() {
     return PER_THREAD_ENTITY_MANAGER_ACCESS;
+  }
+
+  /**
+   * Exposes the properties that will be used to create the entity manager factory.
+   *
+   * @param propertiesConsumer a consumer that will be called with the properties object
+   * @throws IllegalStateException if the entity manager factory has already been created
+   */
+  static void configure(Consumer<PerThreadEntityManagerProperties> propertiesConsumer) {
+    PER_THREAD_ENTITY_MANAGER_ACCESS.configure(propertiesConsumer);
   }
 
   /**

--- a/src/test/java/com/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
+++ b/src/test/java/com/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
@@ -22,6 +22,10 @@ public class PerThreadEntityManagersTest {
   public void entityManagerCanBeConfiguredBeforeInitialization() {
     assertDoesNotThrow(
         () -> access.setProperty("hibernate.connection.url", "jdbc:h2:mem:test"));
+    assertDoesNotThrow(
+        () -> access.setProperties(System.getenv()));
+    assertDoesNotThrow(
+        () -> access.loadProperties("src/test/resources/test.properties"));
   }
 
   @Test

--- a/src/test/java/com/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
+++ b/src/test/java/com/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
@@ -23,18 +23,17 @@ public class PerThreadEntityManagersTest {
   public void entityManagerCanBeConfiguredBeforeDispose() {
     var anotherAccess = new PerThreadEntityManagerAccess(SIMPLE_PERSISTENCE_UNIT_NAME);
 
-    assertDoesNotThrow(
-        () -> anotherAccess.setProperty("hibernate.connection.url", "jdbc:h2:mem:test"));
-    assertDoesNotThrow(
-        () -> anotherAccess.setProperties(System.getenv()));
-    assertDoesNotThrow(
-        () -> anotherAccess.loadProperties("src/test/resources/test.properties"));
+    assertDoesNotThrow(() ->
+      anotherAccess.configure(properties -> properties
+          .set("hibernate.connection.url", "jdbc:h2:mem:test")
+          .putAll(System.getenv())
+          .load("src/test/resources/test.properties"))
+    );
   }
 
   @Test
   public void entityManagerCannotBeConfiguredAfterDispose() {
-    assertThrows(IllegalStateException.class,
-        () -> access.setProperty("hibernate.connection.url", "jdbc:h2:mem:test"));
+    assertThrows(IllegalStateException.class, () -> access.configure(p -> {}));
   }
 
   @Test

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+hibernate.connection.url=jdbc:hsqldb:mem:app-db
+hibernate.connection.username=sa
+hibernate.connection.password=


### PR DESCRIPTION
Esto permitiría setear la conexión con la base de datos después de la compilación, usando variables de entorno o un archivo `*.properties`.

Sería útil al momento de configurar el deploy usando un PaaS sin tener que editar las credenciales a mano o con un script.

Ejemplo de sus formas de uso:
```java
WithSimplePersistenceUnit.configure(properties -> properties
    .set("hibernate.connection.url", "jdbc:h2:mem:test")
    .putAll(System.getenv())
    .load("src/test/resources/test.properties"));
```

> PD: Quizás una alternativa al `set(key, value)` sería agregar un setter para cada property, tipo:
> ```java
> WithSimplePersistenceUnit.configure(properties -> properties
>    .setDriverClassName("org.hsqldb.jdbcDriver")
>    .setUsername("sa")
>    .setPassword("")
>    .setUrl("jdbc:hsqldb:mem:sample-db-" + db));
> ```
> ... o podría permitir ambas formas