### PR TITLE
Create Javalin plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
       <version>2.7.1</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.4.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.javalin</groupId>
       <artifactId>javalin</artifactId>
-      <version>6.0.0-beta.4</version>
+      <version>[6.0.0,7.0.0)</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.javalin</groupId>
+      <artifactId>javalin</artifactId>
+      <version>6.0.0-beta.4</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.5.0</version>

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
@@ -1,32 +1,56 @@
 package io.github.flbulgarelli.jpa.extras.javalin;
 
+import io.github.flbulgarelli.jpa.extras.EntityManagerOps;
+import io.github.flbulgarelli.jpa.extras.TransactionalOps;
+import io.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerAccess;
 import io.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerProperties;
+import io.github.flbulgarelli.jpa.extras.perthread.WithPerThreadEntityManager;
 import io.github.flbulgarelli.jpa.extras.simple.WithSimplePersistenceUnit;
 import io.javalin.config.JavalinConfig;
 import io.javalin.http.Context;
 import io.javalin.plugin.ContextPlugin;
 import java.util.function.Consumer;
+import javax.persistence.EntityManager;
 import org.jetbrains.annotations.NotNull;
 
-public class JavalinJpaExtras extends ContextPlugin<Consumer<PerThreadEntityManagerProperties>, JavalinJpaExtras.Extension> {
+public class JavalinJpaExtras
+      extends ContextPlugin<PerThreadEntityManagerAccess, JavalinJpaExtras>
+      implements WithPerThreadEntityManager, EntityManagerOps, TransactionalOps {
   public JavalinJpaExtras() {
-    this(pluginConfig -> {});
+    this(properties -> {});
   }
 
-  public JavalinJpaExtras(Consumer<PerThreadEntityManagerProperties> pluginConfig) {
-    this.pluginConfig = pluginConfig;
+  public JavalinJpaExtras(Consumer<PerThreadEntityManagerProperties> config) {
+    super(
+        perThreadEntityManagerAccess -> perThreadEntityManagerAccess.configure(config),
+        new PerThreadEntityManagerAccess(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME)
+    );
   }
 
   @Override
   public void onInitialize(JavalinConfig config) {
-    WithSimplePersistenceUnit.configure(pluginConfig);
-    config.router.mount(router -> router.after(ctx -> WithSimplePersistenceUnit.dispose()));
+    config.router.mount(router -> router.after(ctx -> {
+      if (perThreadEntityManagerAccess().isAttached()) {
+        if (getTransaction().isActive()) {
+          throw new IllegalStateException("Can not dispose entity manager if a transaction is active. Ensure it has been already terminated");
+        }
+        perThreadEntityManagerAccess().dispose();
+      }
+    }));
   }
 
   @Override
-  public Extension createExtension(@NotNull Context context) {
-    return new Extension();
+  public JavalinJpaExtras createExtension(@NotNull Context context) {
+    return this;
   }
 
-  public static class Extension implements WithSimplePersistenceUnit {}
+  @Override
+  public EntityManager entityManager() {
+    return perThreadEntityManagerAccess().get();
+  }
+
+  @Override
+  public PerThreadEntityManagerAccess perThreadEntityManagerAccess() {
+    return pluginConfig;
+  }
 }

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
@@ -39,14 +39,7 @@ public class JavalinJpaExtras
   @Override
   public void onInitialize(JavalinConfig config) {
     this.managerAccess.configure(pluginConfig);
-    config.router.mount(router -> router.after(ctx -> {
-      if (perThreadEntityManagerAccess().isAttached()) {
-        if (getTransaction().isActive()) {
-          throw new IllegalStateException("Can not dispose entity manager if a transaction is active. Ensure it has been already terminated");
-        }
-        perThreadEntityManagerAccess().dispose();
-      }
-    }));
+    config.router.mount(router -> router.after(ctx -> WithSimplePersistenceUnit.dispose(managerAccess)));
   }
 
   @Override

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
@@ -1,0 +1,32 @@
+package io.github.flbulgarelli.jpa.extras.javalin;
+
+import io.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerProperties;
+import io.github.flbulgarelli.jpa.extras.simple.WithSimplePersistenceUnit;
+import io.javalin.config.JavalinConfig;
+import io.javalin.http.Context;
+import io.javalin.plugin.ContextPlugin;
+import java.util.function.Consumer;
+import org.jetbrains.annotations.NotNull;
+
+public class JavalinJpaExtras extends ContextPlugin<Consumer<PerThreadEntityManagerProperties>, JavalinJpaExtras.Extension> {
+  public JavalinJpaExtras() {
+    this(pluginConfig -> {});
+  }
+
+  public JavalinJpaExtras(Consumer<PerThreadEntityManagerProperties> pluginConfig) {
+    this.pluginConfig = pluginConfig;
+  }
+
+  @Override
+  public void onInitialize(JavalinConfig config) {
+    WithSimplePersistenceUnit.configure(pluginConfig);
+    config.router.mount(router -> router.after(ctx -> WithSimplePersistenceUnit.dispose()));
+  }
+
+  @Override
+  public Extension createExtension(@NotNull Context context) {
+    return new Extension();
+  }
+
+  public static class Extension implements WithSimplePersistenceUnit {}
+}

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/javalin/JavalinJpaExtras.java
@@ -16,14 +16,24 @@ import org.jetbrains.annotations.NotNull;
 public class JavalinJpaExtras
       extends ContextPlugin<PerThreadEntityManagerAccess, JavalinJpaExtras>
       implements WithPerThreadEntityManager, EntityManagerOps, TransactionalOps {
+  private static final String SIMPLE_PERSISTENCE_UNIT_NAME = WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME;
+
   public JavalinJpaExtras() {
-    this(properties -> {});
+    this(SIMPLE_PERSISTENCE_UNIT_NAME);
+  }
+
+  public JavalinJpaExtras(String persistenceUnitName) {
+    this(persistenceUnitName, properties -> {});
   }
 
   public JavalinJpaExtras(Consumer<PerThreadEntityManagerProperties> config) {
+    this(SIMPLE_PERSISTENCE_UNIT_NAME, config);
+  }
+
+  public JavalinJpaExtras(String persistenceUnitName, Consumer<PerThreadEntityManagerProperties> config) {
     super(
         perThreadEntityManagerAccess -> perThreadEntityManagerAccess.configure(config),
-        new PerThreadEntityManagerAccess(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME)
+        new PerThreadEntityManagerAccess(persistenceUnitName)
     );
   }
 

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
@@ -54,21 +54,11 @@ public interface WithSimplePersistenceUnit extends WithPerThreadEntityManager, E
    * @see PerThreadEntityManagerAccess#dispose()
    */
   static void dispose() {
-    dispose(PER_THREAD_ENTITY_MANAGER_ACCESS);
-  }
-
-  /**
-   * Disposes the given entity manager attached to the current thread, if any.
-   * As an additional validation, it will fail if transaction is active
-   *
-   * @see PerThreadEntityManagerAccess#dispose()
-   */
-  static void dispose(PerThreadEntityManagerAccess managerAccess) {
-    if (managerAccess.isAttached()) {
-      if (managerAccess.get().getTransaction().isActive()) {
+    if (PER_THREAD_ENTITY_MANAGER_ACCESS.isAttached()) {
+      if (PER_THREAD_ENTITY_MANAGER_ACCESS.get().getTransaction().isActive()) {
         throw new IllegalStateException("Can not dispose entity manager if a transaction is active. Ensure it has been already terminated");
       }
-      managerAccess.dispose();
+      PER_THREAD_ENTITY_MANAGER_ACCESS.dispose();
     }
   }
 }

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/simple/WithSimplePersistenceUnit.java
@@ -54,11 +54,21 @@ public interface WithSimplePersistenceUnit extends WithPerThreadEntityManager, E
    * @see PerThreadEntityManagerAccess#dispose()
    */
   static void dispose() {
-    if (PER_THREAD_ENTITY_MANAGER_ACCESS.isAttached()) {
-      if (PER_THREAD_ENTITY_MANAGER_ACCESS.get().getTransaction().isActive()) {
+    dispose(PER_THREAD_ENTITY_MANAGER_ACCESS);
+  }
+
+  /**
+   * Disposes the given entity manager attached to the current thread, if any.
+   * As an additional validation, it will fail if transaction is active
+   *
+   * @see PerThreadEntityManagerAccess#dispose()
+   */
+  static void dispose(PerThreadEntityManagerAccess managerAccess) {
+    if (managerAccess.isAttached()) {
+      if (managerAccess.get().getTransaction().isActive()) {
         throw new IllegalStateException("Can not dispose entity manager if a transaction is active. Ensure it has been already terminated");
       }
-      PER_THREAD_ENTITY_MANAGER_ACCESS.dispose();
+      managerAccess.dispose();
     }
   }
 }

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
@@ -3,6 +3,8 @@ package io.github.flbulgarelli.jpa.extras;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.github.flbulgarelli.jpa.extras.javalin.JavalinJpaExtras;
+import io.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerAccess;
+import io.github.flbulgarelli.jpa.extras.simple.WithSimplePersistenceUnit;
 import io.javalin.Javalin;
 import java.io.IOException;
 import java.net.URI;
@@ -12,14 +14,22 @@ import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JavalinJpaExtrasTest {
+  private PerThreadEntityManagerAccess managerAccess;
+
+  @BeforeEach
+  void setUp() {
+    managerAccess = new PerThreadEntityManagerAccess(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME);
+  }
+
   @Test
   void canConfigureJavalinApp() throws IOException, InterruptedException, ExecutionException {
     var emFuture = new CompletableFuture<EntityManager>();
 
-    Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras()))
+    Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras(managerAccess)))
         .get("/", ctx -> {
           var em = ctx.with(JavalinJpaExtras.class).entityManager();
           emFuture.complete(em);

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
@@ -14,9 +14,9 @@ import java.util.concurrent.ExecutionException;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 
-public class JavalinJpaExtrasTest {
+class JavalinJpaExtrasTest {
   @Test
-  public void canConfigureJavalinApp() throws IOException, InterruptedException, ExecutionException {
+  void canConfigureJavalinApp() throws IOException, InterruptedException, ExecutionException {
     var emFuture = new CompletableFuture<EntityManager>();
 
     Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras()))

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
@@ -1,0 +1,36 @@
+package io.github.flbulgarelli.jpa.extras;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.flbulgarelli.jpa.extras.javalin.JavalinJpaExtras;
+import io.javalin.Javalin;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+
+public class JavalinJpaExtrasTest {
+  @Test
+  public void canConfigureJavalinApp() throws IOException, InterruptedException, ExecutionException {
+    var emFuture = new CompletableFuture<EntityManager>();
+
+    Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras()))
+        .get("/", ctx -> {
+          var em = ctx.with(JavalinJpaExtras.class).entityManager();
+          emFuture.complete(em);
+        })
+        .start(8080);
+
+    HttpClient.newHttpClient().send(
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/")).build(),
+        HttpResponse.BodyHandlers.discarding()
+    );
+
+    assertNotNull(emFuture.get());
+  }
+}

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JavalinJpaExtrasTest.java
@@ -29,15 +29,15 @@ class JavalinJpaExtrasTest {
   void canConfigureJavalinApp() throws IOException, InterruptedException, ExecutionException {
     var emFuture = new CompletableFuture<EntityManager>();
 
-    Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras(managerAccess)))
+    var app = Javalin.create(javalinConfig -> javalinConfig.registerPlugin(new JavalinJpaExtras(managerAccess)))
         .get("/", ctx -> {
           var em = ctx.with(JavalinJpaExtras.class).entityManager();
           emFuture.complete(em);
         })
-        .start(8080);
+        .start();
 
     HttpClient.newHttpClient().send(
-        HttpRequest.newBuilder().uri(URI.create("http://localhost:8080/")).build(),
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:%d/".formatted(app.port()))).build(),
         HttpResponse.BodyHandlers.discarding()
     );
 

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JpaSchemaExportTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JpaSchemaExportTest.java
@@ -16,30 +16,37 @@ class JpaSchemaExportTest {
     var schema = Files.createTempFile("schema", ".sql");
     JpaSchemaExport.execute(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME, schema.toString(), false);
     assertEquals(
-            "create sequence hibernate_sequence start with 1 increment by 1;\n" +
-                    "create table Persistables (id bigint not null, aDate date, aString varchar(255), primary key (id));\n" +
-                    "create table Users (id bigint not null, primary key (id));\n",
-            Files.readString(schema));
+        """
+        create sequence hibernate_sequence start with 1 increment by 1;%1$s\
+        create table Persistables (id bigint not null, aDate date, aString varchar(255), primary key (id));%1$s\
+        create table Users (id bigint not null, primary key (id));%1$s\
+        """.formatted(System.lineSeparator()),
+        Files.readString(schema)
+    );
   }
 
   @Test
   void canGenerateSchemaWithFormat() throws IOException {
     var schema = Files.createTempFile("schema", ".sql");
     JpaSchemaExport.execute(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME, schema.toString(), true);
-    assertEquals("create sequence hibernate_sequence start with 1 increment by 1;\n" +
-                    "\n" +
-                    "    create table Persistables (\n" +
-                    "       id bigint not null,\n" +
-                    "        aDate date,\n" +
-                    "        aString varchar(255),\n" +
-                    "        primary key (id)\n" +
-                    "    );\n" +
-                    "\n" +
-                    "    create table Users (\n" +
-                    "       id bigint not null,\n" +
-                    "        primary key (id)\n" +
-                    "    );\n",
-            Files.readString(schema));
+    assertEquals(
+        """
+        create sequence hibernate_sequence start with 1 increment by 1;%1$s\
+        %1$s\
+            create table Persistables (%1$s\
+               id bigint not null,%1$s\
+                aDate date,%1$s\
+                aString varchar(255),%1$s\
+                primary key (id)%1$s\
+            );%1$s\
+        %1$s\
+            create table Users (%1$s\
+               id bigint not null,%1$s\
+                primary key (id)%1$s\
+            );%1$s\
+        """.formatted(System.lineSeparator()),
+        Files.readString(schema)
+    );
   }
 
 }


### PR DESCRIPTION
Vi la [nueva versión de Javalin](https://javalin.io/migration-guide-javalin-5-to-6) y se me ocurrió que estaría bueno hacer un plugin de JPAExtras para Javalin que permita:

1) Evitar los habituales problemas de concurrencia haciendo el cleanup desde el mismo plugin.
2) Configurar el acceso a la base de datos.

Ejemplo de uso:
```java
var app = Javalin.create(javalinConfig -> {
  var jpaExtras = new JavalinJpaExtras(jpaConfig -> jpaConfig.properties
      .set("hibernate.connection.url", System.getenv("DATABASE_URL"))
      .set("hibernate.connection.username", System.getenv("DATABASE_USERNAME"))
      .set("hibernate.connection.password", System.getenv("DATABASE_PASSWORD"))
  );
  javalinConfig.registerPlugin(jpaExtras);
});
```

Ref: [How to write a Javalin plugin](https://javalin.io/plugins/how-to#creating-a-plugin-with-config-and-extension)