### PR TITLE
Inject JPAQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,10 @@
     </dependency>
 
     <dependency>
-      <groupId>com.intellij</groupId>
+      <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>9.0.4</version>
+      <version>24.1.0</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- dependency test -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
       <version>5.6.12.Final</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.intellij</groupId>
+      <artifactId>annotations</artifactId>
+      <version>9.0.4</version>
+    </dependency>
+
     <!-- dependency test -->
 
     <dependency>

--- a/src/main/java/io/github/flbulgarelli/jpa/extras/EntityManagerOps.java
+++ b/src/main/java/io/github/flbulgarelli/jpa/extras/EntityManagerOps.java
@@ -3,6 +3,7 @@ package io.github.flbulgarelli.jpa.extras;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Mixin for adding simple access to common CRUD {@link EntityManager} operations.
@@ -44,14 +45,14 @@ public interface EntityManagerOps extends WithEntityManager {
   /**
    * @see EntityManager#createQuery(String)
    */
-  default Query createQuery(String qlString) {
+  default Query createQuery(@Language("JPAQL") String qlString) {
     return entityManager().createQuery(qlString);
   }
 
   /**
    * @see EntityManager#createQuery(String, Class)
    */
-  default <T> TypedQuery<T> createQuery(String qlString, Class<T> clazz) {
+  default <T> TypedQuery<T> createQuery(@Language("JPAQL") String qlString, Class<T> clazz) {
     return entityManager().createQuery(qlString, clazz);
   }
 

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/JpaSchemaExportTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/JpaSchemaExportTest.java
@@ -16,30 +16,38 @@ class JpaSchemaExportTest {
     var schema = Files.createTempFile("schema", ".sql");
     JpaSchemaExport.execute(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME, schema.toString(), false);
     assertEquals(
-            "create sequence hibernate_sequence start with 1 increment by 1;\n" +
-                    "create table Persistables (id bigint not null, aDate date, aString varchar(255), primary key (id));\n" +
-                    "create table Users (id bigint not null, primary key (id));\n",
-            Files.readString(schema));
+        """
+        create sequence hibernate_sequence start with 1 increment by 1;%1$s\
+        create table Persistables (id bigint not null, aDate date, aString varchar(255), primary key (id));%1$s\
+        create table Users (id bigint not null, name varchar(255), primary key (id));%1$s\
+        """.formatted(System.lineSeparator()),
+        Files.readString(schema)
+    );
   }
 
   @Test
   void canGenerateSchemaWithFormat() throws IOException {
     var schema = Files.createTempFile("schema", ".sql");
     JpaSchemaExport.execute(WithSimplePersistenceUnit.SIMPLE_PERSISTENCE_UNIT_NAME, schema.toString(), true);
-    assertEquals("create sequence hibernate_sequence start with 1 increment by 1;\n" +
-                    "\n" +
-                    "    create table Persistables (\n" +
-                    "       id bigint not null,\n" +
-                    "        aDate date,\n" +
-                    "        aString varchar(255),\n" +
-                    "        primary key (id)\n" +
-                    "    );\n" +
-                    "\n" +
-                    "    create table Users (\n" +
-                    "       id bigint not null,\n" +
-                    "        primary key (id)\n" +
-                    "    );\n",
-            Files.readString(schema));
+    assertEquals(
+        """
+        create sequence hibernate_sequence start with 1 increment by 1;%1$s\
+        %1$s\
+            create table Persistables (%1$s\
+               id bigint not null,%1$s\
+                aDate date,%1$s\
+                aString varchar(255),%1$s\
+                primary key (id)%1$s\
+            );%1$s\
+        %1$s\
+            create table Users (%1$s\
+               id bigint not null,%1$s\
+                name varchar(255),%1$s\
+                primary key (id)%1$s\
+            );%1$s\
+        """.formatted(System.lineSeparator()),
+        Files.readString(schema)
+    );
   }
 
 }

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/PerThreadEntityManagersTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.flbulgarelli.jpa.extras.perthread.PerThreadEntityManagerAccess;
 import io.github.flbulgarelli.jpa.extras.simple.WithSimplePersistenceUnit;
+import org.hibernate.cfg.AvailableSettings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +25,7 @@ public class PerThreadEntityManagersTest {
 
     assertDoesNotThrow(() ->
       anotherAccess.configure(properties -> properties
-          .set("hibernate.connection.url", "jdbc:h2:mem:test")
+          .set(AvailableSettings.URL, "jdbc:h2:mem:test")
           .putAll(System.getenv())
           .load("src/test/resources/test.properties"))
     );

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/SampleUser.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/SampleUser.java
@@ -11,8 +11,13 @@ public class SampleUser {
   @Id
   @GeneratedValue
   private Long id;
+  private String name;
 
   public Long getId() {
     return id;
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/src/test/java/io/github/flbulgarelli/jpa/extras/SampleUserRepository.java
+++ b/src/test/java/io/github/flbulgarelli/jpa/extras/SampleUserRepository.java
@@ -13,4 +13,10 @@ public class SampleUserRepository implements WithSimplePersistenceUnit {
   public SampleUser find(Long id) {
     return find(SampleUser.class, id);
   }
+
+  public SampleUser findByName(String name) {
+    return createQuery("select u from SampleUser u where u.name = :name", SampleUser.class)
+        .setParameter("name", name)
+        .getSingleResult();
+  }
 }


### PR DESCRIPTION
Esto es para que el IDE sepa que el primer parámetro de `createQuery` es un JPAQL string y pueda, por ejemplo, reconocer si el atributo existe.

Antes:
![Screenshot from 2024-02-11 01-24-39](https://github.com/flbulgarelli/jpa-extras/assets/39303639/650c90db-9d24-4925-9904-8013df3fe55b)

Después:
![Screenshot from 2024-02-11 01-25-10](https://github.com/flbulgarelli/jpa-extras/assets/39303639/e14c4484-4215-430b-bc88-93084686ae34)

![image](https://github.com/flbulgarelli/jpa-extras/assets/39303639/3b57280e-cd68-4456-9048-2cdba107ae69)

![image](https://github.com/flbulgarelli/jpa-extras/assets/39303639/dcd5701e-92cd-4660-8951-ad6dc3e61b89)
